### PR TITLE
Fix README no-hyphenation example to compile against current API

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ let text =
     |> fun s -> s.Replace("\r", "").Replace ("\n", " ")
 
 // For monospace output (e.g. terminal), use DefaultMonospace options and monospaceGlue
-let noHyphenation (_: string) = [||]
+let noHyphenation (_: string) = FilteredPriorities.unfiltered [||]
 Text.format
     (LineBreakOptions.DefaultMonospace 80.0f)
     Text.defaultWordWidth
@@ -88,7 +88,7 @@ You must supply your own hyphenation callback to `Text.format`, which should ret
 (All odd values mean "hyphenation allowed" equally, and all even values mean "no hyphenation allowed" equally; their numerical magnitude is an artifact of the computation that extracted hyphenation data from the Liang packed-trie data structure, and is not important for performing the hyphenation.)
 
 For English text, consider using a Knuth-Liang implementation such as [WoofWare.LiangHyphenation](https://github.com/Smaug123/WoofWare.LiangHyphenation).
-If you don't need hyphenation, pass a function that returns an empty array: `fun _ -> Array.empty`.
+If you don't need hyphenation, pass a function that returns no priorities: `fun _ -> FilteredPriorities.unfiltered Array.empty`.
 
 ### Justification vs raggedness
 


### PR DESCRIPTION
## Summary
The primary README example no longer compiled: `Text.format` now requires the hyphenation callback to return `FilteredPriorities`, but the example returned a raw `byte array`, failing with FS0001.

- Wrap the empty array with `FilteredPriorities.unfiltered` in the main example
- Update the equivalent advice in the Limitations section (`fun _ -> FilteredPriorities.unfiltered Array.empty`)

## Verification
The test suite compiles the identical expression against the same `Text.format` signature (`TestHelpers.noHyphenation`, `TestHelpers.everywhereHyphenation`), confirming the corrected snippet typechecks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)