### PR TITLE
Remove unused FitnessClassDifferencePenalty option

### DIFF
--- a/WoofWare.KnuthPlass/Domain.fs
+++ b/WoofWare.KnuthPlass/Domain.fs
@@ -169,10 +169,6 @@ type LineBreakOptions =
         DoubleHyphenDemerits : float32
         /// Penalty for ending a paragraph with a hyphen
         FinalHyphenDemerits : float32
-        /// <summary>Multiplier by which to penalise consecutive lines having different fitness classes.</summary>
-        /// <remarks>See the <see cref="FitnessClass"/> type for what a fitness class is.
-        /// Note: TeX only applies adj_demerits when fitness diff > 1, not for adjacent classes (diff=1).</remarks>
-        FitnessClassDifferencePenalty : float32
         /// <summary>Zero-width glue providing baseline stretch for all lines (TeX's \rightskip).</summary>
         /// <remarks>
         /// This provides baseline stretchability so that single-word lines (which have no inter-word glue)
@@ -201,8 +197,6 @@ type LineBreakOptions =
     static member DefaultDoubleHyphenDemerits = 10000.0f
     /// Default penalty for ending a paragraph with a hyphen
     static member DefaultFinalHyphenDemerits = 5000.0f
-    /// Default penalty for fitness class differences
-    static member DefaultFitnessClassDifferencePenalty = 100.0f
 
     /// Creates default options with standard TeX values (RightSkip = 0).
     static member Default (lineWidth : float32) =
@@ -213,7 +207,6 @@ type LineBreakOptions =
             AdjacentLooseTightDemerits = LineBreakOptions.DefaultAdjacentLooseTightDemerits
             DoubleHyphenDemerits = LineBreakOptions.DefaultDoubleHyphenDemerits
             FinalHyphenDemerits = LineBreakOptions.DefaultFinalHyphenDemerits
-            FitnessClassDifferencePenalty = LineBreakOptions.DefaultFitnessClassDifferencePenalty
             RightSkip =
                 {
                     Width = 0.0f
@@ -253,7 +246,6 @@ type LineBreakOptions =
             AdjacentLooseTightDemerits = LineBreakOptions.DefaultAdjacentLooseTightDemerits
             DoubleHyphenDemerits = LineBreakOptions.DefaultDoubleHyphenDemerits
             FinalHyphenDemerits = LineBreakOptions.DefaultFinalHyphenDemerits
-            FitnessClassDifferencePenalty = LineBreakOptions.DefaultFitnessClassDifferencePenalty
             // RightSkip.Stretch = 4.0 provides baseline stretchability for single-word lines.
             // This prevents all underfull single-word lines from being treated as equally bad
             // (which would cause unnecessary hyphenation).

--- a/WoofWare.KnuthPlass/SurfaceBaseline.txt
+++ b/WoofWare.KnuthPlass/SurfaceBaseline.txt
@@ -76,13 +76,12 @@ WoofWare.KnuthPlass.LineBreaker inherit obj
 WoofWare.KnuthPlass.LineBreaker.breakLines [static method]: WoofWare.KnuthPlass.LineBreakOptions -> WoofWare.KnuthPlass.Item [] -> WoofWare.KnuthPlass.Line []
 WoofWare.KnuthPlass.LineBreaker.isValidBreakpoint [static method]: WoofWare.KnuthPlass.Item [] -> int -> bool
 WoofWare.KnuthPlass.LineBreakOptions inherit obj, implements WoofWare.KnuthPlass.LineBreakOptions System.IEquatable, System.Collections.IStructuralEquatable, WoofWare.KnuthPlass.LineBreakOptions System.IComparable, System.IComparable, System.Collections.IStructuralComparable
-WoofWare.KnuthPlass.LineBreakOptions..ctor [constructor]: (single, single, single, single, single, single, single, WoofWare.KnuthPlass.Glue)
+WoofWare.KnuthPlass.LineBreakOptions..ctor [constructor]: (single, single, single, single, single, single, WoofWare.KnuthPlass.Glue)
 WoofWare.KnuthPlass.LineBreakOptions.AdjacentLooseTightDemerits [property]: [read-only] single
 WoofWare.KnuthPlass.LineBreakOptions.Default [static method]: single -> WoofWare.KnuthPlass.LineBreakOptions
 WoofWare.KnuthPlass.LineBreakOptions.DefaultAdjacentLooseTightDemerits [static property]: [read-only] single
 WoofWare.KnuthPlass.LineBreakOptions.DefaultDoubleHyphenDemerits [static property]: [read-only] single
 WoofWare.KnuthPlass.LineBreakOptions.DefaultFinalHyphenDemerits [static property]: [read-only] single
-WoofWare.KnuthPlass.LineBreakOptions.DefaultFitnessClassDifferencePenalty [static property]: [read-only] single
 WoofWare.KnuthPlass.LineBreakOptions.DefaultLinePenalty [static property]: [read-only] single
 WoofWare.KnuthPlass.LineBreakOptions.DefaultMonospace [static method]: single -> WoofWare.KnuthPlass.LineBreakOptions
 WoofWare.KnuthPlass.LineBreakOptions.DefaultTolerance [static property]: [read-only] single
@@ -90,17 +89,14 @@ WoofWare.KnuthPlass.LineBreakOptions.DefaultWithRightSkip [static method]: singl
 WoofWare.KnuthPlass.LineBreakOptions.DoubleHyphenDemerits [property]: [read-only] single
 WoofWare.KnuthPlass.LineBreakOptions.Equals [method]: (WoofWare.KnuthPlass.LineBreakOptions, System.Collections.IEqualityComparer) -> bool
 WoofWare.KnuthPlass.LineBreakOptions.FinalHyphenDemerits [property]: [read-only] single
-WoofWare.KnuthPlass.LineBreakOptions.FitnessClassDifferencePenalty [property]: [read-only] single
 WoofWare.KnuthPlass.LineBreakOptions.get_AdjacentLooseTightDemerits [method]: unit -> single
 WoofWare.KnuthPlass.LineBreakOptions.get_DefaultAdjacentLooseTightDemerits [static method]: unit -> single
 WoofWare.KnuthPlass.LineBreakOptions.get_DefaultDoubleHyphenDemerits [static method]: unit -> single
 WoofWare.KnuthPlass.LineBreakOptions.get_DefaultFinalHyphenDemerits [static method]: unit -> single
-WoofWare.KnuthPlass.LineBreakOptions.get_DefaultFitnessClassDifferencePenalty [static method]: unit -> single
 WoofWare.KnuthPlass.LineBreakOptions.get_DefaultLinePenalty [static method]: unit -> single
 WoofWare.KnuthPlass.LineBreakOptions.get_DefaultTolerance [static method]: unit -> single
 WoofWare.KnuthPlass.LineBreakOptions.get_DoubleHyphenDemerits [method]: unit -> single
 WoofWare.KnuthPlass.LineBreakOptions.get_FinalHyphenDemerits [method]: unit -> single
-WoofWare.KnuthPlass.LineBreakOptions.get_FitnessClassDifferencePenalty [method]: unit -> single
 WoofWare.KnuthPlass.LineBreakOptions.get_LinePenalty [method]: unit -> single
 WoofWare.KnuthPlass.LineBreakOptions.get_LineWidth [method]: unit -> single
 WoofWare.KnuthPlass.LineBreakOptions.get_RightSkip [method]: unit -> WoofWare.KnuthPlass.Glue

--- a/WoofWare.KnuthPlass/version.json
+++ b/WoofWare.KnuthPlass/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3",
+  "version": "0.4",
   "publicReleaseRefSpec": [
     "^refs/heads/main$"
   ],


### PR DESCRIPTION
## Summary
`LineBreakOptions.FitnessClassDifferencePenalty` was documented as a public option but never read anywhere in production code — changing it could not alter any layout. The behaviour its docs describe is already provided by `AdjacentLooseTightDemerits` (TeX's `adj_demerits`, added when consecutive lines' fitness classes differ by more than 1, LineBreaker.fs demerits computation). TeX itself has only the one knob.

Rather than inventing a second, non-TeX demerits term to make the option "do something", this removes it: an option that silently does nothing is a trap for callers.

- Remove the record field and `DefaultFitnessClassDifferencePenalty`
- Update `SurfaceBaseline.txt` accordingly
- Bump version 0.3 → 0.4 (pre-1.0 breaking API change)

## Verification
Full suite: 248 tests pass, including `Ensure API surface has not been modified` (validating the updated baseline) and `CheckVersionAgainstRemote`. Fantomas and analyzers clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)